### PR TITLE
removes upgrade button next to search bar

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -18,7 +18,9 @@ angular.module('DuckieTorrent.controllers', ['DuckieTorrent.torrent'])
             'gui.show_plus_av_upsell': false,
             'offers.content_offer_autoexec': false,
             'offers.featured_content_notifications_enabled': false,
-            'offers.featured_content_rss_enabled': false
+            'offers.featured_content_rss_enabled': false,
+            'offers.upgrade_panel': false,
+            'offers.upgrade_toolbar': false
         };
 
         $scope.Pair = function() {


### PR DESCRIPTION
Fixes #7. Here is a helpful hint to get the flags.
Press `Shift` + `F2` while clicking on Options > Preferences which will show hidden flags.
I added `offers.upgrade_toolbar` and `offers.upgrade_panel` to be set to false.
